### PR TITLE
regex w2t now works for http:// URLs

### DIFF
--- a/tor2web/t2w.py
+++ b/tor2web/t2w.py
@@ -808,8 +808,7 @@ class T2WRequest(http.Request):
                     args = {}
 
                     ctype = self.requestHeaders.getRawHeaders(b'content-type')
-                    if ctype is not None:
-                        ctype = ctype[0]
+                    ctype = ctype[0] if ctype is not None
 
                     if self.method == b"POST" and ctype:
                         key, pdict = parse_header(ctype)
@@ -1380,7 +1379,7 @@ ipv6 = config.listen_ipv6
 
 rexp = {
     'body': re.compile(r'(<body.*?\s*>)', re.I),
-    'w2t': re.compile(r'(https.?:)?//([a-z0-9]{16}).' + config.basehost, re.I),
+    'w2t': re.compile(r'(http:|https:)?//([a-z0-9]{16}).' + config.basehost, re.I),
     't2w': re.compile(r'(http.?:)?//([a-z0-9]{16})\.onion', re.I),
     'html_t2w': re.compile( r'(href|src|url|action)[\ ]*(=[\ ]*[\'"])http[s]?://([a-z0-9]{16})\.onion([\'"/])', re.I),
     'set-cookie_t2w': re.compile(r'domain=(\.*)([a-z0-9]{16})\.onion(\b)?', re.I)


### PR DESCRIPTION
Had an issue with request header "Referer: http://xxxxx.onion.city/path/to/file.html" not being properly replaced to be '.onion' URLs.  This change to w2t fixes that.  The w2t regex is only used in one place, and you can verify that it gives the correct behavior.

The other is a tweak on ctype's assignment to be prettier.